### PR TITLE
Add RTestFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Plug 'mllg/vim-devtools-plugin', { 'for': ['r', 'rmd', 'rnoweb']}
 * `RBuildPackage <dir>`: Runs `devtools::build`.
 * `RCheckPackage <dir>`: Runs `devtools::check`.
 * `RTestPackage <dir> <filter>`: Runs `devtools::test` using specified filter (default `''`).
+* `RTestFile`: Runs `devtools::test` setting a filter to test the current file.
 * `RDocumentPackage <dir>`: Runs `devtools::document`
 * `RMakePackage <dir>`: Runs `devtools::document`, then `devtools::install`.
 * `RSetupTest <dir>`: Loads "testthat" and invisibly sources all files matching pattern `^helper` in the test directory.

--- a/autoload/devtools.vim
+++ b/autoload/devtools.vim
@@ -52,6 +52,12 @@ function! devtools#test(...)
 endfunction
 
 
+function! devtools#test_file()
+    let l:filter = '"' . substitute(expand('%:t:r'), '^test[-_]', '', '') . '"'
+    call devtools#test(l:filter)
+endfunction
+
+
 function! devtools#make(...)
     let l:desc = devtools#find_description(a:000)
     if (l:desc != '')

--- a/plugin/devtools.vim
+++ b/plugin/devtools.vim
@@ -14,6 +14,7 @@ command! -complete=dir -nargs=? RCheckPackage :call devtools#simple_cmd('check',
 command! -complete=dir -nargs=? RDocumentPackage :call devtools#simple_cmd('document', <f-args>)
 command! -complete=dir -nargs=? RClean :call devtools#simple_cmd('clean_dll', <f-args>)
 command! -complete=dir -nargs=* RTestPackage :call devtools#test(<f-args>)
+command! RTestFile :call devtools#test_file()
 command! -complete=dir -nargs=? RMake :call devtools#make(<f-args>)
 command! -complete=dir -nargs=? RSetupTest :call devtools#setup_test(<f-args>)
 command! -complete=dir -nargs=? RBuildPackageTags :call devtools#build_tags(<f-args>)


### PR DESCRIPTION
Dear Michael,

thanks for your great `vim-devtools-plugin`. I use it nearly daily.

Currently I find it a little bit cumbersome to run `:RTestPackage <part_of_my_filename>` to run `devtools::test(filter="part_of_my_filename")`. This PR adds `RTestFile` that determines `<part_of_my_filename>` on its own by removing `^test[-_]` and the file extension.

I hope you like the idea. Please don't hesitate to ask me to improve the PR.

Best wishes,

Sebastian